### PR TITLE
Fix trees_to_dataframe method of XGBoost and Sklearn wrappers

### DIFF
--- a/skgbm/wrappers/sklearn_wrapper.py
+++ b/skgbm/wrappers/sklearn_wrapper.py
@@ -12,7 +12,7 @@ class _SklearnWrapper(_GBMWrapper):
         return np.squeeze(self.estimator.apply(X))
     
     def trees_to_dataframe(self):
-        return sklearn_trees_to_dataframe(self)
+        return sklearn_trees_to_dataframe(self.estimator)
     
     def learning_rate(self):
         return self.estimator.learning_rate

--- a/skgbm/wrappers/xgboost_wrapper.py
+++ b/skgbm/wrappers/xgboost_wrapper.py
@@ -23,7 +23,7 @@ class _XgboostWrapper(_GBMWrapper):
         return self.estimator._Booster.predict(xgb.DMatrix(X), pred_leaf=True)
     
     def trees_to_dataframe(self):
-        return xgboost_trees_to_dataframe(self)
+        return xgboost_trees_to_dataframe(self.estimator)
     
     def learning_rate(self):
         eta = self.config['learner']['gradient_booster']['updater'] \


### PR DESCRIPTION
This MR fixes usage of `xgboost_trees_to_dataframe` usage in `_XGBoostWrapper` class as well as `sklearn_trees_to_dataframe` usage in `_SklearnWrapper` class.


 If only `self` is passed to `xgboost_trees_to_dataframe` method it fails with missing attribute error as mentioned in #17 . As it can be observed in `__init__` of the xgboost wrapper class, one needs to access `.get_booster()` method from `self.estimator` attribute which this MR implements as a fix.

As for sklearn wrapper - a similar situation was found where `.estimators_` was called on the wrapper class itself instead of the sklearn estimator and this attribute is only accessible on a fitted sklearn estimator, so for future improvements, one could use the `is_fitted` method from `xgbm/utils.py` to evade sklearn errors (possible issue when the discretizer's `.transform` method is called without `.fit`, `.fit_transform` should be safe.


Both fixes are verified and tested from the forked repo:
<img width="876" alt="image" src="https://github.com/user-attachments/assets/f79bab7c-47e3-4f6e-a123-f4fc57413e80">
